### PR TITLE
Add Email addr to contact page

### DIFF
--- a/kontakt/index.html
+++ b/kontakt/index.html
@@ -22,6 +22,7 @@ keywords: články, české budějovice, politika, pohled
       <h2>ČEPICE - Českobudějovické Pirátské centrum</h2>
       <p>Hradební 13, 37001 České Budějovice</p><br><br>
       <p>Tel: <a href="tel:778702243">+420 778 702 243</a></p>
+      <p>Email: <a href="mailto:ceskobudejovicko@pirati.cz">ceskobudejovicko@pirati.cz</a></p>
       <p>Facebook: <a href="https://www.facebook.com/PiratiCB/" target="_blank">www.facebook.com/PiratiCB</a></p>
     </section>
 <br><br>


### PR DESCRIPTION
Na stránce kontakt chybí emailová adresa, lidi co nepouživají FB nás nemají jak kontaktovat mimo telefon!